### PR TITLE
Remove redundant for loop in UserManagerTest

### DIFF
--- a/app/src/test/java/com/amigo/user/UserManagerTest.java
+++ b/app/src/test/java/com/amigo/user/UserManagerTest.java
@@ -38,9 +38,7 @@ public class UserManagerTest {
         UserManager manager = new UserManager(db);
         List<User> listOfUsers = db.getUsers();
         Map<String, User> allUsers = manager.getUsers();
-        for (User user : listOfUsers) {
-            assertEquals(allUsers.size(), 9);
-        }
+        assertEquals(allUsers.size(), 9);
         for (User user : allUsers.values()) {
             boolean hasUser = false;
             for (User user2 : listOfUsers) {


### PR DESCRIPTION
There was a redundant for loop in UserManagerTest that repeated the same assertion 9 times. I have removed it and now it asserts only once.